### PR TITLE
get_fee to default zero and remove pybitcointools b58 dependency

### DIFF
--- a/electrum/registeraddress_script.py
+++ b/electrum/registeraddress_script.py
@@ -4,7 +4,7 @@ from .util import bh2u, bfh
 from .transaction import opcodes
 import base64
 import binascii
-from bitcoin import b58check_to_bin
+from .bitcoin import b58_address_to_hash160
                       
 class RegisterAddressScript():
 	def __init__(self, wallet):
@@ -17,7 +17,7 @@ class RegisterAddressScript():
 
 	def append(self, addrs):
 		for addr in addrs:
-			self.payload.extend(b58check_to_bin(addr))
+			self.payload.extend(b58_address_to_hash160(addr)[1])
 			pubkeybytes=bfh(self.wallet.get_public_key(addr, tweaked=False))
 			self.payload.extend(pubkeybytes)
 

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -1128,10 +1128,6 @@ class Transaction:
         ser = self.serialize_to_network(witness=True)
         return bh2u(Hash(bfh(ser))[::-1])
 
-    def add_inputs(self, inputs):
-        self._inputs.extend(inputs)
-        self.raw = None
-
     def add_outputs(self, outputs):
         self._outputs.extend(outputs)
         self.raw = None
@@ -1148,9 +1144,8 @@ class Transaction:
         for o in self.outputs():
             if o.type == TYPE_SCRIPT and o.address == '':
                 return o.value
-        # if fee output has not been added it will return
-        # the original fee sum of input - sum of output value
-        return self.input_value() - self.output_value()
+        # if fee output has not been added it will return 0
+        return 0
 
     def is_final(self):
         return not any([x.get('sequence', 0xffffffff - 1) < 0xffffffff - 1 for x in self.inputs()])

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -40,7 +40,7 @@ from functools import partial
 from numbers import Number
 from decimal import Decimal
 from io import StringIO, BytesIO
-from bitcoin import bin_to_b58check
+from .bitcoin import hash160_to_b58_address
 
 from .i18n import _
 from .util import (NotEnoughFunds, PrintError, UserCancelled, profiler,
@@ -1396,7 +1396,7 @@ class Abstract_Wallet(AddressSynchronizer):
             if i3 > ptlen:
                 break
             addrbytes=bytes(data[i1:i2])
-            addrs.append(bin_to_b58check(addrbytes, constants.net.ADDRTYPE_P2PKH))
+            addrs.append(hash160_to_b58_address(addrbytes, constants.net.ADDRTYPE_P2PKH))
         
         self.set_pending_state(addrs, False)
         self.set_registered_state(addrs, True)


### PR DESCRIPTION
b58_to_bin and bin_to_b58 from pybitcointools replaced with native functions to remove dependency. 
transaction.get_fee() defaults to zero if no explicit fee output (fixes crash with zero-fee redemption and burn transactions. 