### PR TITLE
unassigned_kyc_pubkeys were not being saved in the wallet because the…

### DIFF
--- a/electrum/address_synchronizer.py
+++ b/electrum/address_synchronizer.py
@@ -451,7 +451,7 @@ class AddressSynchronizer(PrintError):
             self.storage.put('tx_fees', self.tx_fees)
             self.storage.put('addr_history', self.history)
             self.storage.put('spent_outpoints', self.spent_outpoints)
-            self.storage.put('unassigned_kyc_pubkeys', list(self.unassigned_kyc_pubkeys))
+            self.storage.put('unassigned_kyc_pubkeys', dict.fromkeys(self.unassigned_kyc_pubkeys,0))
             self.storage.put('kyc_pubkey', self.kyc_pubkey)
             if write:
                 self.storage.write()
@@ -694,7 +694,7 @@ class AddressSynchronizer(PrintError):
                             ba2=bytearray(payload[3:])
                             ba2.reverse()
                             data = bh2u(ba1+ba2)
-                            self.unassigned_kyc_pubkeys.remove(bfh(data))
+                            self.unassigned_kyc_pubkeys.remove(data)
 
         #Check outputs for address data (assign)
         for output in tx.outputs():
@@ -714,7 +714,7 @@ class AddressSynchronizer(PrintError):
                 ba2.reverse()
                 data = bh2u(ba1+ba2)
 
-                self.unassigned_kyc_pubkeys.add(bfh(data))
+                self.unassigned_kyc_pubkeys.add(data)
 
         return (datatype==TYPE_DATA)
 

--- a/electrum/storage.py
+++ b/electrum/storage.py
@@ -89,8 +89,8 @@ class JsonDB(PrintError):
         try:
             json.dumps(key, cls=util.MyEncoder)
             json.dumps(value, cls=util.MyEncoder)
-        except:
-            self.print_error("json error: cannot save", key)
+        except Exception as err:
+            self.print_error("{0}: json error: cannot save ".format(err), key)
             return
         with self.db_lock:
             if value is not None:

--- a/electrum/wallet.py
+++ b/electrum/wallet.py
@@ -1887,14 +1887,14 @@ class Standard_Wallet(Simple_Deterministic_Wallet):
             ss.write("\n")
 
         #Encrypt the addresses string
-        encrypted = ecc.ECPubkey(onboardPubKey).encrypt_message(bytes(ss.getvalue(), 'utf-8'), ephemeral=onboardUserKey)
+        encrypted = ecc.ECPubkey(bfh(onboardPubKey)).encrypt_message(bytes(ss.getvalue(), 'utf-8'), ephemeral=onboardUserKey)
 
         ss2 = StringIO()
         str_encrypted=str(encrypted)
         #Remove the b'' characters (first 2 and last characters)
         str_encrypted=str_encrypted[2:]
         str_encrypted=str_encrypted[:-1]
-        ss2.write("{} {} {}\n".format(bh2u(onboardPubKey), ''.join(onboardUserPubKey), str(len(str_encrypted))))
+        ss2.write("{} {} {}\n".format(onboardPubKey, ''.join(onboardUserPubKey), str(len(str_encrypted))))
         ss2.write(str_encrypted)
         kyc_string=ss2.getvalue()
 


### PR DESCRIPTION
… key format has to be "string", (was "bytes").