### PR TITLE
Verify header proof

### DIFF
--- a/electrum/blockchain.py
+++ b/electrum/blockchain.py
@@ -83,7 +83,11 @@ def verify_header_proof(h):
 
     d = {}
     pushdata = op_push(int(len(challenge)/2))
-    parse_scriptSig(d, bytearray.fromhex(proof+pushdata+challenge))
+    try:
+        parse_scriptSig(d, bytearray.fromhex(proof+pushdata+challenge))
+    except struct.error:
+        return False
+
     rhhash = hash_header(h)
     hhash = "".join(reversed([rhhash[i:i+2] for i in range(0, len(rhhash), 2)]))
 

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -301,12 +301,6 @@ def script_GetOp(_bytes : bytes):
                 (nSize,) = struct.unpack_from('<H', _bytes, i)
                 i += 2
             elif opcode == opcodes.OP_PUSHDATA4:
-                #if len(_bytes[i:]) <  struct.calcsize('<I'):
-                #    '''Set a tracepoint in the Python debugger that works with Qt'''
-                #    from PyQt5.QtCore import pyqtRemoveInputHook
-                #    from pdb import set_trace
-                #    pyqtRemoveInputHook()
-                #    set_trace()
                 (nSize,) = struct.unpack_from('<I', _bytes, i)
                 i += 4
             vch = _bytes[i:i + nSize]

--- a/electrum/transaction.py
+++ b/electrum/transaction.py
@@ -301,6 +301,12 @@ def script_GetOp(_bytes : bytes):
                 (nSize,) = struct.unpack_from('<H', _bytes, i)
                 i += 2
             elif opcode == opcodes.OP_PUSHDATA4:
+                #if len(_bytes[i:]) <  struct.calcsize('<I'):
+                #    '''Set a tracepoint in the Python debugger that works with Qt'''
+                #    from PyQt5.QtCore import pyqtRemoveInputHook
+                #    from pdb import set_trace
+                #    pyqtRemoveInputHook()
+                #    set_trace()
                 (nSize,) = struct.unpack_from('<I', _bytes, i)
                 i += 4
             vch = _bytes[i:i + nSize]


### PR DESCRIPTION
Handle struct.error exception thrown from parse_scriptSig() in verify_header_proof by returning False. The "interface" in network.py will then either request a new header or switch to catchup mode in on_notify_header() in network.py (lines 1144 onwards in network.py). This should resolve issue #98 subject to further testing.